### PR TITLE
Adjust MQTT admin subscription permissions to $SYS

### DIFF
--- a/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
+++ b/apps/zotonic_core/src/support/z_mqtt_sessions_runtime.erl
@@ -425,7 +425,7 @@ is_allowed(false, Action, Topic, Packet, Context) ->
 % Check if it is allowed for the admin to subscribe to a topic.
 is_allowed_admin_subscribe([<<"$SYS">>, <<"site">>, Site | _], Context) ->
     case z_context:site(Context) of
-        zotonic_status_site ->
+        zotonic_site_status ->
             % admin of the status site is allowed to subscribe to sys
             % topics of all sites.
             true;
@@ -440,9 +440,14 @@ is_allowed_admin_subscribe([<<"$SYS">>, <<"erlang">> | _], _Context) ->
 is_allowed_admin_subscribe([<<"$SYS">>, <<"statistics">> | _], _Context) ->
     % and to zotonic node wide stats topics
     true;
-is_allowed_admin_subscribe([<<"$SYS">> | _], _Context) ->
-    % other sys topics are disallowed
-    false;
+is_allowed_admin_subscribe([<<"$SYS">> | _], Context) ->
+    % other sys topics are allowed only for zotonic_site_status admin
+    case z_context:site(Context) of
+        zotonic_site_status ->
+            true;
+        _ ->
+            false
+    end;
 is_allowed_admin_subscribe(_, _Context) ->
     true.
 


### PR DESCRIPTION
Fix the wrong site name being applied to `$SYS/site/foo` (causing the test to fail) and allow the zotonic_site_status admin to subscribe to all `$SYS` topics

### Description

Fixes the logic for subscribing over MQTT to  `$SYS/site/<sitename>` for the zotonic admin user (the site name being checked for was incorrect). Additionally, allows that admin user to subscribe to all `$SYS` topics.

### Checklist

- [ ] documentation updated
- [ ] tests added
- [x] no BC breaks
